### PR TITLE
:arrow_up: :art: [TE] Use `boost-ext` instead of `boost-experimental`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# How to contribute
+
+Contributions are always very much appreciated. However, to make sure the
+process of accepting patches goes smoothly for everyone (especially for
+the maintainer), you should try to follow these few simple guidelines when
+you contribute:
+
+1. Fork the repository.
+2. Create a new branch based on the `master` branch (`git checkout -b your_branch master`).
+3. Do your modifications on that branch.
+4. Be sure your modifications include:
+  * Don't break anything (`make`)
+  * Proper unit/functional tests (`make test`)
+5. Commit your changes. Your commit message should reflect your changes.
+6. Push the changes to your fork (`git push origin your_branch`).
+7. Rebase if necessary to avoid broken commits (`git rebase -i origin/master`).
+8. Open a pull request against SML's `master` branch.
+   I will do my best to respond in a timely manner. I might discuss your patch and suggest some modifications, or I might amend your patch myself and ask you for feedback. You will always be given proper credit.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to Reproduce the Problem
+
+  1.
+  1.
+  1.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Problem:
+-
+
+Solution:
+-
+
+Issue: #
+
+Reviewers:
+@

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Boost].TE <a href="http://www.boost.org/LICENSE_1_0.txt" target="_blank">![Boost Licence](http://img.shields.io/badge/license-boost-blue.svg)</a> <a href="https://travis-ci.org/boost-experimental/te" target="_blank">![Build Status](https://img.shields.io/travis/boost-experimental/te/master.svg?label=linux/osx)</a> <a href="https://codecov.io/gh/boost-experimental/te" target="_blank">![Coveralls](https://codecov.io/gh/boost-experimental/te/branch/master/graph/badge.svg)</a> <a href="http://github.com/boost-experimental/te/issues" target="_blank">![Github Issues](https://img.shields.io/github/issues/boost-experimental/te.svg)</a> <a href="https://godbolt.org/g/8YmMLX">![Try it online](https://img.shields.io/badge/try%20it-online-blue.svg)</a>
+# [Boost::ext].TE <a href="http://www.boost.org/LICENSE_1_0.txt" target="_blank">![Boost Licence](http://img.shields.io/badge/license-boost-blue.svg)</a> <a href="https://travis-ci.org/boost-ext/te" target="_blank">![Build Status](https://img.shields.io/travis/boost-ext/te/master.svg?label=linux/osx)</a> <a href="https://codecov.io/gh/boost-ext/te" target="_blank">![Coveralls](https://codecov.io/gh/boost-ext/te/branch/master/graph/badge.svg)</a> <a href="http://github.com/boost-ext/te/issues" target="_blank">![Github Issues](https://img.shields.io/github/issues/boost-ext/te.svg)</a> <a href="https://godbolt.org/g/8YmMLX">![Try it online](https://img.shields.io/badge/try%20it-online-blue.svg)</a>
 
 > Your C++17 **one header only** run-time polymorphism (type erasure) library with no dependencies, macros and limited boilerplate
 
@@ -10,7 +10,7 @@
 
 ### Quick start
 
-> [Boost].TE requires only one file. Get the latest header [here!](https://github.com/boost-experimental/te/blob/master/include/boost/te.hpp)
+> [Boost::ext].TE requires only one file. Get the latest header [here!](https://github.com/boost-ext/te/blob/master/include/boost/te.hpp)
 
 ```cpp
 #include <boost/te.hpp> // Requires C++17 (Tested: GCC-6+, Clang-4.0+, Apple:Clang-9.1+)
@@ -346,7 +346,7 @@ int main() {
 }
 ```
 
-#### Inject it ([[Boost].DI](https://github.com/boost-experimental/di))
+#### Inject it ([[Boost::ext].DI](https://github.com/boost-ext/di))
 
 ```cpp
 class Example {
@@ -395,4 +395,4 @@ int main() {
 
 ---
 
-**Disclaimer** `[Boost].TE` is not an official Boost library.
+**Disclaimer** `[Boost::ext].TE` is not an official Boost library.

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -19,7 +19,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace boost::te {
+namespace boost::inline ext::te {
 inline namespace v1 {
 namespace detail {
 template <class...>
@@ -306,7 +306,7 @@ concept bool conceptify = requires {
 #endif
 
 }  // namespace v1
-}  // namespace boost::te
+}  // namespace boost::ext::te
 
 #if not defined(REQUIRES)
 #define REQUIRES(R, name, ...)                                              \


### PR DESCRIPTION
Problem:
- `boost-experimental` is often misunderstood causing confusion.

Solution:
- Use the new `boost-ext` organization name instead and update all usages of it.