### PR TITLE
:art: :bug: [TE] Fix for `inline ext` namespace

### DIFF
--- a/example/injection.cpp
+++ b/example/injection.cpp
@@ -5,7 +5,7 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 //
-#if __has_include(<boost/di.hpp>)
+#if __has_include(<boost / di.hpp>)
 #include <boost/di.hpp>
 #include <iostream>
 

--- a/example/nonowning.cpp
+++ b/example/nonowning.cpp
@@ -15,14 +15,17 @@ namespace te = boost::te;
 struct Drawable : te::poly<Drawable, te::non_owning_storage> {
   using te::poly<Drawable, te::non_owning_storage>::poly;
 
-  void draw(std::ostream &out)  {
+  void draw(std::ostream &out) {
     te::call([](auto &self, auto &out) { self.draw(out); }, *this, out);
   }
 };
 
 struct Square {
   int value;
-  void draw(std::ostream &out) { out << "Square"; value += 1; }
+  void draw(std::ostream &out) {
+    out << "Square";
+    value += 1;
+  }
 };
 
 struct Circle {

--- a/example/unified.cpp
+++ b/example/unified.cpp
@@ -18,10 +18,12 @@ struct Drawable {
   void draw(std::ostream &out) const {
     te::call(
         [](auto const &self, auto &out) {
-          if constexpr (std::experimental::is_detected<
-                            drawable_t, decltype(self), decltype(out)>{}) {
-            self.draw(out);
-          } else {
+          if
+            constexpr(std::experimental::is_detected<drawable_t, decltype(self),
+                                                     decltype(out)>{}) {
+              self.draw(out);
+            }
+          else {
             ::draw(self, out);
           }
         },

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -19,7 +19,9 @@
 #include <type_traits>
 #include <utility>
 
-namespace boost::inline ext::te {
+namespace boost {
+inline namespace ext {
+namespace te {
 inline namespace v1 {
 namespace detail {
 template <class...>
@@ -146,8 +148,7 @@ class non_owning_storage {
  public:
   template <class T, class T_ = std::decay_t<T> >
   constexpr explicit non_owning_storage(T &&t, detail::void_ptr &ptr) noexcept {
-    ptr.reset(&t,
-              []([[maybe_unused]] void *ptr) {},
+    ptr.reset(&t, []([[maybe_unused]] void *ptr) {},
               [](void *ptr) -> void * { return static_cast<T_ *>(ptr); });
   }
 };
@@ -206,8 +207,9 @@ class poly : detail::poly_base,
              public std::conditional_t<detail::is_complete<I>{}, I,
                                        detail::type_list<I> > {
  public:
-  template <class T, class = std::enable_if_t<
-                         not std::is_convertible<std::decay_t<T>, poly>{}> >
+  template <class T,
+            class = std::enable_if_t<
+                not std::is_convertible<std::decay_t<T>, poly>{}> >
   constexpr poly(T &&t) noexcept
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
@@ -306,17 +308,19 @@ concept bool conceptify = requires {
 #endif
 
 }  // namespace v1
-}  // namespace boost::ext::te
+}  // namespace te
+}  // namespace ext
+}  // namespace boost
 
 #if not defined(REQUIRES)
-#define REQUIRES(R, name, ...)                                              \
-  R {                                                                       \
-    return ::te::call<R>(                                                   \
-        [](auto&& self, auto&&... args)                                     \
-            -> decltype(self.name(std::forward<decltype(args)>(args)...)) { \
-          return self.name(std::forward<decltype(args)>(args)...);          \
-        },                                                                  \
-        *this, ##__VA_ARGS__);                                              \
+#define REQUIRES(R, name, ...)                                     \
+  R {                                                              \
+    return ::te::call<R>(                                          \
+        [](auto&& self, auto&&... args) -> decltype(               \
+            self.name(std::forward<decltype(args)>(args)...)) {    \
+          return self.name(std::forward<decltype(args)>(args)...); \
+        },                                                         \
+        *this, ##__VA_ARGS__);                                     \
   }
 #endif
 

--- a/test/te.cpp
+++ b/test/te.cpp
@@ -9,8 +9,8 @@
 #include <type_traits>
 #include <vector>
 
-#include "common/test.hpp"
 #include "boost/te.hpp"
+#include "common/test.hpp"
 
 namespace te = boost::te;
 
@@ -496,7 +496,6 @@ test should_support_custom_storage = [] {
   }
 };
 
-
 struct DrawableMutable : te::poly<DrawableMutable, te::non_owning_storage> {
   using te::poly<DrawableMutable, te::non_owning_storage>::poly;
 
@@ -506,12 +505,12 @@ struct DrawableMutable : te::poly<DrawableMutable, te::non_owning_storage> {
 };
 
 struct SquareMutable {
-   int value;
+  int value;
 
-   void draw(std::ostream &out) {
-      out << "Square Mutable"; 
-      value += 1;
-   }
+  void draw(std::ostream &out) {
+    out << "Square Mutable";
+    value += 1;
+  }
 };
 
 test should_support_non_owning_storage = [] {
@@ -532,10 +531,10 @@ test should_support_non_owning_storage = [] {
     std::stringstream str{};
     std::vector<DrawableMutable> drawables_mut{b, c};
 
-    for (auto& drawable : drawables_mut) {
+    for (auto &drawable : drawables_mut) {
       draw_mut(drawable, str);
     }
-     
+
     expect("Square MutableSquare Mutable" == str.str());
     expect(1 == b.value);
     expect(1 == c.value);


### PR DESCRIPTION
Problem:
- `boost::inline ext` namespace declaration doesn't compile.

Solution:
- Fix it by splitting into separate namespace declarations.