### PR TITLE
Storage types fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,21 @@ matrix:
     env: CXX=g++-7 VARIANT=coverage
     addons: { apt: { packages: ["g++-7", "libstdc++-7-dev"], sources: ["ubuntu-toolchain-r-test"] } }
 
+  - os: linux
+      dist: trusty
+      env: CXX=g++-8 VARIANT=valgrind
+      addons: { apt: { packages: [ "g++-8", "libstdc++-8-dev" ], sources: [ "ubuntu-toolchain-r-test" ] } }
+
+  - os: linux
+      dist: trusty
+      env: CXX=g++-9 VARIANT=valgrind
+      addons: { apt: { packages: [ "g++-9", "libstdc++-9-dev" ], sources: [ "ubuntu-toolchain-r-test" ] } }
+
+  - os: linux
+      dist: trusty
+      env: CXX=g++-10 VARIANT=valgrind
+      addons: { apt: { packages: [ "g++-10", "libstdc++-10-dev" ], sources: [ "ubuntu-toolchain-r-test" ] } }
+
   - os: osx
     osx_image: xcode9.1
     env: CXX=clang++ VARIANT=valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,21 +45,6 @@ matrix:
     env: CXX=g++-7 VARIANT=coverage
     addons: { apt: { packages: ["g++-7", "libstdc++-7-dev"], sources: ["ubuntu-toolchain-r-test"] } }
 
-  - os: linux
-      dist: trusty
-      env: CXX=g++-8 VARIANT=valgrind
-      addons: { apt: { packages: [ "g++-8", "libstdc++-8-dev" ], sources: [ "ubuntu-toolchain-r-test" ] } }
-
-  - os: linux
-      dist: trusty
-      env: CXX=g++-9 VARIANT=valgrind
-      addons: { apt: { packages: [ "g++-9", "libstdc++-9-dev" ], sources: [ "ubuntu-toolchain-r-test" ] } }
-
-  - os: linux
-      dist: trusty
-      env: CXX=g++-10 VARIANT=valgrind
-      addons: { apt: { packages: [ "g++-10", "libstdc++-10-dev" ], sources: [ "ubuntu-toolchain-r-test" ] } }
-
   - os: osx
     osx_image: xcode9.1
     env: CXX=clang++ VARIANT=valgrind

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,23 +16,18 @@ add_custom_command(TARGET style COMMAND find ${CMAKE_CURRENT_LIST_DIR}/example
   ${CMAKE_CURRENT_LIST_DIR}/include ${CMAKE_CURRENT_LIST_DIR}/test -iname
   "*.hpp" -or -iname "*.cpp" | xargs clang-format -i)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic-errors")
+set(CMAKE_CXX_STANDARD 17)
+add_compile_options(-Wall -Wextra -Werror -pedantic -pedantic-errors)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
+  add_compile_options(-fconcepts)
 endif()
 
 if (ENABLE_COVERAGE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
+  add_compile_options(--coverage -g -O0)
 endif()
 
 if (ENABLE_SANITIZERS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak -fsanitize=undefined")
+  add_compile_options(-O0 -g -fno-omit-frame-pointer -fsanitize=address -fsanitize=leak -fsanitize=undefined)
 endif()
 
 enable_testing()

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -436,6 +436,7 @@ class poly : detail::poly_base,
     class = std::enable_if_t<not std::is_convertible<T_, poly>{}>
   >
   constexpr poly(T &&t)
+      noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
 
@@ -452,6 +453,7 @@ class poly : detail::poly_base,
     class TRequires
   >
   constexpr poly(T &&t, const TRequires)
+      noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              std::make_index_sequence<detail::mappings_size<I>()>{}} {}
 
@@ -461,6 +463,7 @@ class poly : detail::poly_base,
     std::size_t... Ns
   >
   constexpr poly(T &&t, std::index_sequence<Ns...>)
+      noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : detail::poly_base{},
         vtable{std::forward<T>(t), vptr,
                std::integral_constant<std::size_t, sizeof...(Ns)>{}},

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -435,7 +435,7 @@ class poly : detail::poly_base,
     class T_ = std::decay_t<T>,
     class = std::enable_if_t<not std::is_convertible<T_, poly>{}>
   >
-  constexpr poly(T &&t) noexcept(std::is_nothrow_constructible_v<T_,T>)
+  constexpr poly(T &&t)
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
 
@@ -451,7 +451,7 @@ class poly : detail::poly_base,
     class T_ = std::decay_t<T>,
     class TRequires
   >
-  constexpr poly(T &&t, const TRequires) noexcept(std::is_nothrow_constructible_v<T_,T>)
+  constexpr poly(T &&t, const TRequires)
       : poly{std::forward<T>(t),
              std::make_index_sequence<detail::mappings_size<I>()>{}} {}
 
@@ -460,7 +460,7 @@ class poly : detail::poly_base,
     class T_ = std::decay_t<T>,
     std::size_t... Ns
   >
-  constexpr poly(T &&t, std::index_sequence<Ns...>) noexcept(std::is_nothrow_constructible_v<T_,T>)
+  constexpr poly(T &&t, std::index_sequence<Ns...>)
       : detail::poly_base{},
         vtable{std::forward<T>(t), vptr,
                std::integral_constant<std::size_t, sizeof...(Ns)>{}},

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -95,8 +95,6 @@ inline T exchange(T& obj, U&& new_value)
 
 struct non_owning_storage
 {
-  non_owning_storage() noexcept = default;
-
   template <
     class T,
     class T_ = std::decay_t<T>,
@@ -112,8 +110,6 @@ struct non_owning_storage
 
 struct shared_storage
 {
-  shared_storage() noexcept = default;
-
   template <
     class T,
     class T_ = std::decay_t<T>,
@@ -129,8 +125,6 @@ struct shared_storage
 
 struct dynamic_storage
 {
-  dynamic_storage() noexcept = default;
-
   template <
     class T,
     class T_ = std::decay_t<T>,
@@ -207,8 +201,6 @@ template <std::size_t Size, std::size_t Alignment = 8>
 struct local_storage
 {
   using mem_t = std::aligned_storage_t<Size, Alignment>;
-
-  local_storage() noexcept = default;
 
   template <
     class T,
@@ -303,8 +295,6 @@ struct sbo_storage
   struct type_fits : std::integral_constant<bool, sizeof(T_) <= Size && Alignment % alignof(T_) == 0>{};
 
   using mem_t = std::aligned_storage_t<Size, Alignment>;
-
-  sbo_storage() noexcept = default;
 
   template <
     class T,
@@ -419,7 +409,7 @@ class static_vtable {
 
  public:
   template <class T, std::size_t Size>
-  static_vtable(T &&, ptr_t *&vtable,
+  explicit static_vtable(T &&, ptr_t *&vtable,
                 std::integral_constant<std::size_t, Size>) noexcept {
     static ptr_t vt[Size]{};
     vtable = vt;
@@ -446,7 +436,7 @@ class poly : detail::poly_base,
     class T,
     class T_ = std::decay_t<T>,
     std::enable_if_t<!std::is_same_v<T_, poly>, bool> = true
-  >
+  > // cppcheck-suppress noExplicitConstructor
   constexpr poly(T &&t) noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
@@ -467,7 +457,7 @@ class poly : detail::poly_base,
     class T_ = std::decay_t<T>,
     class TRequires
   >
-  constexpr poly(T &&t, const TRequires) noexcept(std::is_nothrow_constructible_v<T_,T&&>)
+  constexpr explicit poly(T &&t, const TRequires) noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              std::make_index_sequence<detail::mappings_size<I>()>{}} {}
 
@@ -476,7 +466,7 @@ class poly : detail::poly_base,
     class T_ = std::decay_t<T>,
     std::size_t... Ns
   >
-  constexpr poly(T &&t, std::index_sequence<Ns...>) noexcept(std::is_nothrow_constructible_v<T_,T&&>)
+  constexpr explicit poly(T &&t, std::index_sequence<Ns...>) noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : detail::poly_base{},
         vtable{std::forward<T>(t), vptr,
                std::integral_constant<std::size_t, sizeof...(Ns)>{}},

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -97,7 +97,11 @@ struct non_owning_storage
 {
   non_owning_storage() noexcept = default;
 
-  template <class T>
+  template <
+    class T,
+    class T_ = std::decay_t<T>,
+    std::enable_if_t<!std::is_same_v<T_,non_owning_storage>, bool> = true
+  >
   constexpr explicit non_owning_storage(T &&t) noexcept
   : ptr{&t}
   {
@@ -109,7 +113,11 @@ struct shared_storage
 {
   shared_storage() noexcept = default;
 
-  template <class T, class T_ = std::decay_t<T>>
+  template <
+    class T,
+    class T_ = std::decay_t<T>,
+    std::enable_if_t<!std::is_same_v<T_,shared_storage>, bool> = true
+  >
   constexpr explicit shared_storage(T &&t) noexcept
   : ptr{std::make_shared<T_>(std::forward<T>(t))}
   {
@@ -122,7 +130,11 @@ struct dynamic_storage
 {
   dynamic_storage() noexcept = default;
 
-  template <class T, class T_ = std::decay_t<T> >
+  template <
+    class T,
+    class T_ = std::decay_t<T>,
+    std::enable_if_t<!std::is_same_v<T_,dynamic_storage>, bool> = true
+  >
   explicit dynamic_storage(T &&t)
       noexcept(noexcept(std::is_nothrow_constructible_v<T_,T>))
   : ptr{new T_{std::forward<T>(t)}},
@@ -192,7 +204,11 @@ struct local_storage
 {
   local_storage() noexcept = default;
 
-  template <class T, class T_ = std::decay_t<T> >
+  template <
+    class T,
+    class T_ = std::decay_t<T>,
+    std::enable_if_t<!std::is_same_v<T_,local_storage>, bool> = true
+  >
   constexpr explicit local_storage(T &&t)
       noexcept(noexcept(std::is_nothrow_constructible_v<T_,T>))
   : ptr{new (&data) T_{std::forward<T>(t)}},
@@ -279,7 +295,11 @@ struct sbo_storage
 
   sbo_storage() noexcept = default;
 
-  template <class T, class T_ = std::decay_t<T> >
+  template <
+    class T,
+    class T_ = std::decay_t<T>,
+    std::enable_if_t<!std::is_same_v<T_,sbo_storage>, bool> = true
+  >
   constexpr explicit sbo_storage(T &&t)
   : sbo_storage()
   {

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -424,8 +424,11 @@ struct poly_base {
 };
 }  // namespace detail
 
-template <class I, class TStorage = dynamic_storage,
-          class TVtable = static_vtable>
+template <
+  class I,
+  class TStorage = dynamic_storage,
+  class TVtable = static_vtable
+>
 class poly : detail::poly_base,
              public std::conditional_t<detail::is_complete<I>{}, I,
                                        detail::type_list<I> > {
@@ -433,17 +436,21 @@ class poly : detail::poly_base,
   template <
     class T,
     class T_ = std::decay_t<T>,
-    class = std::enable_if_t<not std::is_convertible<T_, poly>{}>
+    class = std::enable_if_t<not std::is_convertible<T_, poly>::value>
   >
   constexpr poly(T &&t)
       noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
 
-  constexpr poly(poly const &) = default;
-  constexpr poly &operator=(poly const &) = default;
-  constexpr poly(poly &&) = default;
-  constexpr poly &operator=(poly &&) = default;
+  constexpr poly(poly const &)
+      noexcept(std::is_nothrow_copy_constructible_v<TStorage>) = default;
+  constexpr poly &operator=(poly const &)
+      noexcept(std::is_nothrow_copy_constructible_v<TStorage>) = default;
+  constexpr poly(poly &&)
+      noexcept(std::is_nothrow_move_constructible_v<TStorage>) = default;
+  constexpr poly &operator=(poly &&)
+      noexcept(std::is_nothrow_move_constructible_v<TStorage>) = default;
 
  private:
 

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -159,10 +159,12 @@ struct dynamic_storage
 
   constexpr dynamic_storage& operator=(const dynamic_storage& other)
   {
-    reset();
-    ptr  = other.ptr ? other.copy(other.ptr) : nullptr;
-    del  = other.del;
-    copy = other.copy;
+    if (other.ptr != ptr) {
+      reset();
+      ptr   = other.ptr ? other.copy(other.ptr) : nullptr;
+      del   = other.del;
+      copy  = other.copy;
+    }
     return *this;
   }
 
@@ -175,10 +177,12 @@ struct dynamic_storage
 
   constexpr dynamic_storage& operator=(dynamic_storage&& other)
   {
-    reset();
-    ptr   = detail::exchange(other.ptr, nullptr);
-    del   = detail::exchange(other.del, nullptr);
-    copy  = detail::exchange(other.copy, nullptr);
+    if (other.ptr != ptr) {
+      reset();
+      ptr   = detail::exchange(other.ptr, nullptr);
+      del   = detail::exchange(other.del, nullptr);
+      copy  = detail::exchange(other.copy, nullptr);
+    }
     return *this;
   }
 
@@ -242,11 +246,13 @@ struct local_storage
 
   constexpr local_storage& operator=(const local_storage& other)
   {
-    reset();
-    ptr  = other.ptr ? other.copy(other.ptr, &data) : nullptr;
-    del  = other.del;
-    copy = other.copy;
-    move = other.move;
+    if (other.ptr != ptr) {
+      reset();
+      ptr   = other.ptr ? other.copy(other.ptr, &data) : nullptr;
+      del   = other.del;
+      copy  = other.copy;
+      move  = other.move;
+    }
     return *this;
   }
 
@@ -260,11 +266,13 @@ struct local_storage
 
   constexpr local_storage& operator=(local_storage&& other)
   {
-    reset();
-    ptr  = other.ptr ? other.move(other.ptr, &data) : nullptr;
-    del  = other.del;
-    copy = other.copy;
-    move = other.move;
+    if (other.ptr != ptr) {
+      reset();
+      ptr   = other.ptr ? other.move(other.ptr, &data) : nullptr;
+      del   = other.del;
+      copy  = other.copy;
+      move  = other.move;
+    }
     return *this;
   }
 
@@ -356,11 +364,13 @@ struct sbo_storage
 
   constexpr sbo_storage& operator=(const sbo_storage& other)
   {
-    reset();
-    ptr  = other.ptr ? other.copy(other.ptr, &data) : nullptr;
-    del  = other.del;
-    copy = other.copy;
-    move = other.move;
+    if (other.ptr != ptr) {
+      reset();
+      ptr   = other.ptr ? other.copy(other.ptr, &data) : nullptr;
+      del   = other.del;
+      copy  = other.copy;
+      move  = other.move;
+    }
     return *this;
   }
 
@@ -374,11 +384,13 @@ struct sbo_storage
 
   constexpr sbo_storage& operator=(sbo_storage&& other)
   {
-    reset();
-    ptr  = other.ptr ? other.move(other.ptr, &data) : nullptr;
-    del  = other.del;
-    copy = other.copy;
-    move = other.move;
+    if (other.ptr != ptr) {
+      reset();
+      ptr   = other.ptr ? other.move(other.ptr, &data) : nullptr;
+      del   = other.del;
+      copy  = other.copy;
+      move  = other.move;
+    }
     return *this;
   }
 

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -439,7 +439,7 @@ class poly : detail::poly_base,
     class = std::enable_if_t<not std::is_convertible<T_, poly>::value>
   >
   constexpr poly(T &&t)
-      noexcept(std::is_nothrow_constructible_v<T_,T&&>)
+      noexcept //(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
 

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -257,7 +257,6 @@ struct sbo_storage
 
   template <class T, class T_ = std::decay_t<T> >
   constexpr explicit sbo_storage(T &&t)
-      noexcept(noexcept(std::is_nothrow_constructible_v<T_,T>))
   : sbo_storage()
   {
     if constexpr (type_fits<T_>::value)

--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -436,8 +436,9 @@ class poly : detail::poly_base,
     class T,
     class T_ = std::decay_t<T>,
     std::enable_if_t<!std::is_same_v<T_, poly>, bool> = true
-  > // cppcheck-suppress noExplicitConstructor
-  constexpr poly(T &&t) noexcept(std::is_nothrow_constructible_v<T_,T&&>)
+  >
+  constexpr poly(T &&t) // cppcheck-suppress noExplicitConstructor
+      noexcept(std::is_nothrow_constructible_v<T_,T&&>)
       : poly{std::forward<T>(t),
              detail::type_list<decltype(detail::requires__<I>(bool{}))>{}} {}
 

--- a/test/te.cpp
+++ b/test/te.cpp
@@ -38,27 +38,6 @@ test should_return_mappings_size = [] {
       te::detail::mappings_size<class Size, std::integral_constant<int, 1>>());
 };
 
-test should_support_void_ptr = [] {
-  te::detail::void_ptr ptr{new int{42}};
-  expect(42 == *ptr.get<int>());
-
-  int &i = *ptr.get<int>();
-  ++i;
-  expect(43 == *ptr.get<int>());
-
-  te::detail::void_ptr copy{ptr};
-  expect(43 == *copy.get<int>());
-
-  te::detail::void_ptr copy_assign = ptr;
-  expect(43 == *copy_assign.get<int>());
-
-  te::detail::void_ptr move{std::move(ptr)};
-  expect(43 == *move.get<int>());
-
-  te::detail::void_ptr move_assign = std::move(ptr);
-  expect(43 == *move.get<int>());
-};
-
 struct Drawable {
   void draw(std::ostream &out) const {
     te::call([](auto const &self, auto &out) { self.draw(out); }, *this, out);
@@ -445,8 +424,7 @@ test should_support_dynamic_storage = [] {
   Storage::calls<Dtor>() = 0;
 
   {
-    te::detail::void_ptr ptr{};
-    te::dynamic_storage storage{Storage{}, ptr};
+    te::dynamic_storage storage{Storage{}};
   }
 
   expect(1 == Storage::calls<Ctor>());
@@ -461,9 +439,8 @@ test should_support_local_storage = [] {
   Storage::calls<MoveCtor>() = 0;
   Storage::calls<Dtor>() = 0;
 
-  {
-    te::detail::void_ptr ptr{};
-    te::local_storage<16> storage{Storage{}, ptr};
+  {;
+    te::local_storage<16> storage{Storage{}};
   }
 
   expect(1 == Storage::calls<Ctor>());


### PR DESCRIPTION
Problem:
- Local storage didn't work
- Move constructors of erased type were being called in copy constructors of poly

Solution:
- Storage types handle memory manually. So longer need `void_ptr`
- Deleted copy semantics are converted to exceptions in polys
- Deleted move semantics are converted to exceptions in polys

Issue: #31

Reviewers:
@krzysztof-jusiak 