### PR TITLE
remove type specifiers before conceptify

### DIFF
--- a/include/boost/te.hpp
+++ b/include/boost/te.hpp
@@ -568,13 +568,13 @@ constexpr auto extends(const T &) noexcept {
 
 #if defined(__cpp_concepts)
 template <class I, class T>
-concept bool var = requires {
+concept var = requires {
   detail::requires_impl<I, T>(
       std::make_index_sequence<detail::mappings_size<T, I>()>{});
 };
 
 template <class I, class T>
-concept bool conceptify = requires {
+concept conceptify = requires {
   detail::requires_impl<I, T>(
       std::make_index_sequence<detail::mappings_size<T, I>()>{});
 };


### PR DESCRIPTION
Something like a typed concept is ill formed and doesn't make sense anyway since it's not a type.

Problem:
-
When using `conceptify` on Clang 16.0.6, compilation will fail with:
```
te.hpp:571:14: error: ISO C++ does not permit the 'bool' keyword after 'concept'
concept bool var = requires {
             ^
te.hpp:577:14: error: ISO C++ does not permit the 'bool' keyword after 'concept'
concept bool conceptify = requires {
```

Solution:
-
Remove the bool keyword in front of the two concepts, as they are not types.


